### PR TITLE
Added restrict_sr flag to Subreddit.search()

### DIFF
--- a/lib/src/subreddit.dart
+++ b/lib/src/subreddit.dart
@@ -28,7 +28,7 @@ class Subreddit extends Object with Listings {
   /**
    * Allowed filters are "after", "before", "count", "limit", "restrict_sr", "show", "sort", "syntax", "t".
    */
-  FilterableQuery search(String query) => new FilterableQuery._(_reddit, _res("search"), {"q": query},
+  FilterableQuery search(String query) => new FilterableQuery._(_reddit, _res("search"), {"q": query, "restrict_sr": true},
       ["after", "before", "count", "limit", "restrict_sr", "show", "sort", "syntax", "t"]);
 
   @override


### PR DESCRIPTION
Subreddit.search() defaults to searching the entirety of reddit. By adding the restrict_sr flag, the search will be restricted to the relevant subreddit.